### PR TITLE
feat: add service and deployment management enhancements

### DIFF
--- a/docs/deployment/variables/default.md
+++ b/docs/deployment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/deployment.ts:123](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/deployment.ts#L123)
+Defined in: [src/resources/deployment.ts:123](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/deployment.ts#L123)
 
 ## Type declaration
 

--- a/docs/deployment/variables/default.md
+++ b/docs/deployment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/deployment.ts:150](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/deployment.ts#L150)
+Defined in: [src/resources/deployment.ts:150](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/deployment.ts#L150)
 
 ## Type declaration
 

--- a/docs/deployment/variables/default.md
+++ b/docs/deployment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/deployment.ts:150](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/deployment.ts#L150)
+Defined in: [src/resources/deployment.ts:157](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/deployment.ts#L157)
 
 ## Type declaration
 
@@ -34,21 +34,31 @@ The ID of the deployment to cancel
 
 > **create**: (`input`) => `Promise`\<`boolean`\>
 
+Create a deployment
+
 #### Parameters
 
 ##### input
+
+The input parameters
 
 ###### commitSha?
 
 `string`
 
+The commit SHA to deploy
+
 ###### environmentId
 
 `string`
 
+The ID of the environment
+
 ###### serviceId
 
 `string`
+
+The ID of the service
 
 #### Returns
 

--- a/docs/deployment/variables/default.md
+++ b/docs/deployment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/deployment.ts:123](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/deployment.ts#L123)
+Defined in: [src/resources/deployment.ts:150](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/deployment.ts#L150)
 
 ## Type declaration
 
@@ -25,6 +25,30 @@ Cancel a deployment
 `string`
 
 The ID of the deployment to cancel
+
+#### Returns
+
+`Promise`\<`boolean`\>
+
+### create()
+
+> **create**: (`input`) => `Promise`\<`boolean`\>
+
+#### Parameters
+
+##### input
+
+###### commitSha?
+
+`string`
+
+###### environmentId
+
+`string`
+
+###### serviceId
+
+`string`
 
 #### Returns
 

--- a/docs/environment/functions/create.md
+++ b/docs/environment/functions/create.md
@@ -8,7 +8,7 @@
 
 > **create**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/environment.ts#L45)
+Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L45)
 
 Create an environment
 

--- a/docs/environment/functions/create.md
+++ b/docs/environment/functions/create.md
@@ -8,7 +8,7 @@
 
 > **create**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L45)
+Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/environment.ts#L45)
 
 Create an environment
 

--- a/docs/environment/functions/create.md
+++ b/docs/environment/functions/create.md
@@ -8,7 +8,7 @@
 
 > **create**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L45)
+Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L45)
 
 Create an environment
 

--- a/docs/environment/functions/create.md
+++ b/docs/environment/functions/create.md
@@ -8,7 +8,7 @@
 
 > **create**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L45)
+Defined in: [src/resources/environment.ts:45](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L45)
 
 Create an environment
 

--- a/docs/environment/functions/createToken.md
+++ b/docs/environment/functions/createToken.md
@@ -8,7 +8,7 @@
 
 > **createToken**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L127)
+Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L127)
 
 Create an environment token
 

--- a/docs/environment/functions/createToken.md
+++ b/docs/environment/functions/createToken.md
@@ -8,7 +8,7 @@
 
 > **createToken**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L127)
+Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/environment.ts#L127)
 
 Create an environment token
 

--- a/docs/environment/functions/createToken.md
+++ b/docs/environment/functions/createToken.md
@@ -8,7 +8,7 @@
 
 > **createToken**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L127)
+Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L127)
 
 Create an environment token
 

--- a/docs/environment/functions/createToken.md
+++ b/docs/environment/functions/createToken.md
@@ -8,7 +8,7 @@
 
 > **createToken**(`input`): `Promise`\<`string`\>
 
-Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/environment.ts#L127)
+Defined in: [src/resources/environment.ts:127](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L127)
 
 Create an environment token
 

--- a/docs/environment/functions/deleteToken.md
+++ b/docs/environment/functions/deleteToken.md
@@ -8,7 +8,7 @@
 
 > **deleteToken**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/environment.ts#L76)
+Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L76)
 
 Delete an environment token
 

--- a/docs/environment/functions/deleteToken.md
+++ b/docs/environment/functions/deleteToken.md
@@ -8,7 +8,7 @@
 
 > **deleteToken**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L76)
+Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L76)
 
 Delete an environment token
 

--- a/docs/environment/functions/deleteToken.md
+++ b/docs/environment/functions/deleteToken.md
@@ -8,7 +8,7 @@
 
 > **deleteToken**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L76)
+Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/environment.ts#L76)
 
 Delete an environment token
 

--- a/docs/environment/functions/deleteToken.md
+++ b/docs/environment/functions/deleteToken.md
@@ -8,7 +8,7 @@
 
 > **deleteToken**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L76)
+Defined in: [src/resources/environment.ts:76](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L76)
 
 Delete an environment token
 

--- a/docs/environment/functions/get.md
+++ b/docs/environment/functions/get.md
@@ -8,7 +8,7 @@
 
 > **get**(`input`): `Promise`\<`null` \| `string`\>
 
-Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/environment.ts#L16)
+Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L16)
 
 Get an environment by name
 

--- a/docs/environment/functions/get.md
+++ b/docs/environment/functions/get.md
@@ -8,7 +8,7 @@
 
 > **get**(`input`): `Promise`\<`null` \| `string`\>
 
-Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L16)
+Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L16)
 
 Get an environment by name
 

--- a/docs/environment/functions/get.md
+++ b/docs/environment/functions/get.md
@@ -8,7 +8,7 @@
 
 > **get**(`input`): `Promise`\<`null` \| `string`\>
 
-Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L16)
+Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/environment.ts#L16)
 
 Get an environment by name
 

--- a/docs/environment/functions/get.md
+++ b/docs/environment/functions/get.md
@@ -8,7 +8,7 @@
 
 > **get**(`input`): `Promise`\<`null` \| `string`\>
 
-Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L16)
+Defined in: [src/resources/environment.ts:16](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L16)
 
 Get an environment by name
 

--- a/docs/environment/functions/waitForDeployment.md
+++ b/docs/environment/functions/waitForDeployment.md
@@ -8,7 +8,7 @@
 
 > **waitForDeployment**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L163)
+Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L163)
 
 Wait for a deployment to complete
 

--- a/docs/environment/functions/waitForDeployment.md
+++ b/docs/environment/functions/waitForDeployment.md
@@ -8,7 +8,7 @@
 
 > **waitForDeployment**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L163)
+Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/environment.ts#L163)
 
 Wait for a deployment to complete
 

--- a/docs/environment/functions/waitForDeployment.md
+++ b/docs/environment/functions/waitForDeployment.md
@@ -8,7 +8,7 @@
 
 > **waitForDeployment**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L163)
+Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L163)
 
 Wait for a deployment to complete
 

--- a/docs/environment/functions/waitForDeployment.md
+++ b/docs/environment/functions/waitForDeployment.md
@@ -8,7 +8,7 @@
 
 > **waitForDeployment**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/environment.ts#L163)
+Defined in: [src/resources/environment.ts:163](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L163)
 
 Wait for a deployment to complete
 

--- a/docs/environment/variables/default.md
+++ b/docs/environment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L269)
+Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/environment.ts#L269)
 
 ## Type declaration
 

--- a/docs/environment/variables/default.md
+++ b/docs/environment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/environment.ts#L269)
+Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L269)
 
 ## Type declaration
 

--- a/docs/environment/variables/default.md
+++ b/docs/environment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/environment.ts#L269)
+Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L269)
 
 ## Type declaration
 

--- a/docs/environment/variables/default.md
+++ b/docs/environment/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/environment.ts#L269)
+Defined in: [src/resources/environment.ts:269](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/environment.ts#L269)
 
 ## Type declaration
 

--- a/docs/index/variables/default.md
+++ b/docs/index/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/index.ts#L7)
+Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/index.ts#L7)
 
 ## Type declaration
 
@@ -29,6 +29,30 @@ Cancel a deployment
 `string`
 
 The ID of the deployment to cancel
+
+##### Returns
+
+`Promise`\<`boolean`\>
+
+#### deployment.create()
+
+> **create**: (`input`) => `Promise`\<`boolean`\>
+
+##### Parameters
+
+###### input
+
+###### commitSha?
+
+`string`
+
+###### environmentId
+
+`string`
+
+###### serviceId
+
+`string`
 
 ##### Returns
 
@@ -348,25 +372,37 @@ The service ID
 
 > **createDomain**: (`input`) => `Promise`\<`string`\>
 
+Create a service domain
+
 ##### Parameters
 
 ###### input
+
+The input parameters
 
 ###### environmentId
 
 `string`
 
+The ID of the environment
+
 ###### serviceId
 
 `string`
+
+The ID of the service
 
 ###### targetPort
 
 `number`
 
+The target port for the domain
+
 ##### Returns
 
 `Promise`\<`string`\>
+
+The created domain
 
 #### service.getById()
 
@@ -392,41 +428,61 @@ The service
 
 > **getDomains**: (`input`) => `Promise`\<\{ `customDomain`: `null` \| `string`; `serviceDomain`: `null` \| `string`; \}\>
 
+Get domains for a service in an environment
+
 ##### Parameters
 
 ###### input
 
+The input parameters
+
 ###### environmentId
 
 `string`
+
+The ID of the environment
 
 ###### projectId
 
 `string`
 
+The ID of the project
+
 ###### serviceId
 
 `string`
+
+The ID of the service
 
 ##### Returns
 
 `Promise`\<\{ `customDomain`: `null` \| `string`; `serviceDomain`: `null` \| `string`; \}\>
 
+The custom and service domains
+
 #### service.getForEnvironment()
 
 > **getForEnvironment**: (`input`) => `Promise`\<`object`[]\>
+
+Get all service instances for an environment
 
 ##### Parameters
 
 ###### input
 
+The input parameters
+
 ###### environmentId
 
 `string`
 
+The ID of the environment
+
 ##### Returns
 
 `Promise`\<`object`[]\>
+
+Array of service instances with their domains
 
 ### variable
 

--- a/docs/index/variables/default.md
+++ b/docs/index/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/index.ts#L7)
+Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/index.ts#L7)
 
 ## Type declaration
 
@@ -38,21 +38,31 @@ The ID of the deployment to cancel
 
 > **create**: (`input`) => `Promise`\<`boolean`\>
 
+Create a deployment
+
 ##### Parameters
 
 ###### input
+
+The input parameters
 
 ###### commitSha?
 
 `string`
 
+The commit SHA to deploy
+
 ###### environmentId
 
 `string`
 
+The ID of the environment
+
 ###### serviceId
 
 `string`
+
+The ID of the service
 
 ##### Returns
 

--- a/docs/index/variables/default.md
+++ b/docs/index/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/index.ts#L7)
+Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/index.ts#L7)
 
 ## Type declaration
 

--- a/docs/index/variables/default.md
+++ b/docs/index/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/index.ts#L7)
+Defined in: [src/resources/index.ts:7](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/index.ts#L7)
 
 ## Type declaration
 
@@ -411,6 +411,22 @@ The service
 ##### Returns
 
 `Promise`\<\{ `customDomain`: `null` \| `string`; `serviceDomain`: `null` \| `string`; \}\>
+
+#### service.getForEnvironment()
+
+> **getForEnvironment**: (`input`) => `Promise`\<`object`[]\>
+
+##### Parameters
+
+###### input
+
+###### environmentId
+
+`string`
+
+##### Returns
+
+`Promise`\<`object`[]\>
 
 ### variable
 

--- a/docs/project/variables/default.md
+++ b/docs/project/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/project.ts#L34)
+Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/project.ts#L34)
 
 ## Type declaration
 

--- a/docs/project/variables/default.md
+++ b/docs/project/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/project.ts#L34)
+Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/project.ts#L34)
 
 ## Type declaration
 

--- a/docs/project/variables/default.md
+++ b/docs/project/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/project.ts#L34)
+Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/project.ts#L34)
 
 ## Type declaration
 

--- a/docs/project/variables/default.md
+++ b/docs/project/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/project.ts#L34)
+Defined in: [src/resources/project.ts:34](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/project.ts#L34)
 
 ## Type declaration
 

--- a/docs/service/functions/getById.md
+++ b/docs/service/functions/getById.md
@@ -8,7 +8,7 @@
 
 > **getById**(`serviceId`): `Promise`\<\{ `id`: `string`; `name`: `string`; \}\>
 
-Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/service.ts#L12)
+Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/service.ts#L12)
 
 Get a service by ID
 

--- a/docs/service/functions/getById.md
+++ b/docs/service/functions/getById.md
@@ -8,7 +8,7 @@
 
 > **getById**(`serviceId`): `Promise`\<\{ `id`: `string`; `name`: `string`; \}\>
 
-Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/service.ts#L12)
+Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/service.ts#L12)
 
 Get a service by ID
 

--- a/docs/service/functions/getById.md
+++ b/docs/service/functions/getById.md
@@ -8,7 +8,7 @@
 
 > **getById**(`serviceId`): `Promise`\<\{ `id`: `string`; `name`: `string`; \}\>
 
-Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/service.ts#L12)
+Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/service.ts#L12)
 
 Get a service by ID
 

--- a/docs/service/functions/getById.md
+++ b/docs/service/functions/getById.md
@@ -8,7 +8,7 @@
 
 > **getById**(`serviceId`): `Promise`\<\{ `id`: `string`; `name`: `string`; \}\>
 
-Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/service.ts#L12)
+Defined in: [src/resources/service.ts:12](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/service.ts#L12)
 
 Get a service by ID
 

--- a/docs/service/variables/default.md
+++ b/docs/service/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/service.ts:148](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/service.ts#L148)
+Defined in: [src/resources/service.ts:170](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/service.ts#L170)
 
 ## Type declaration
 
@@ -16,25 +16,37 @@ Defined in: [src/resources/service.ts:148](https://github.com/meistrari/railway-
 
 > **createDomain**: (`input`) => `Promise`\<`string`\>
 
+Create a service domain
+
 #### Parameters
 
 ##### input
+
+The input parameters
 
 ###### environmentId
 
 `string`
 
+The ID of the environment
+
 ###### serviceId
 
 `string`
+
+The ID of the service
 
 ###### targetPort
 
 `number`
 
+The target port for the domain
+
 #### Returns
 
 `Promise`\<`string`\>
+
+The created domain
 
 ### getById()
 
@@ -60,38 +72,58 @@ The service
 
 > **getDomains**: (`input`) => `Promise`\<\{ `customDomain`: `null` \| `string`; `serviceDomain`: `null` \| `string`; \}\>
 
+Get domains for a service in an environment
+
 #### Parameters
 
 ##### input
 
+The input parameters
+
 ###### environmentId
 
 `string`
+
+The ID of the environment
 
 ###### projectId
 
 `string`
 
+The ID of the project
+
 ###### serviceId
 
 `string`
+
+The ID of the service
 
 #### Returns
 
 `Promise`\<\{ `customDomain`: `null` \| `string`; `serviceDomain`: `null` \| `string`; \}\>
 
+The custom and service domains
+
 ### getForEnvironment()
 
 > **getForEnvironment**: (`input`) => `Promise`\<`object`[]\>
+
+Get all service instances for an environment
 
 #### Parameters
 
 ##### input
 
+The input parameters
+
 ###### environmentId
 
 `string`
 
+The ID of the environment
+
 #### Returns
 
 `Promise`\<`object`[]\>
+
+Array of service instances with their domains

--- a/docs/service/variables/default.md
+++ b/docs/service/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/service.ts:170](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/service.ts#L170)
+Defined in: [src/resources/service.ts:170](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/service.ts#L170)
 
 ## Type declaration
 

--- a/docs/service/variables/default.md
+++ b/docs/service/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/service.ts:92](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/service.ts#L92)
+Defined in: [src/resources/service.ts:148](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/service.ts#L148)
 
 ## Type declaration
 
@@ -79,3 +79,19 @@ The service
 #### Returns
 
 `Promise`\<\{ `customDomain`: `null` \| `string`; `serviceDomain`: `null` \| `string`; \}\>
+
+### getForEnvironment()
+
+> **getForEnvironment**: (`input`) => `Promise`\<`object`[]\>
+
+#### Parameters
+
+##### input
+
+###### environmentId
+
+`string`
+
+#### Returns
+
+`Promise`\<`object`[]\>

--- a/docs/service/variables/default.md
+++ b/docs/service/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/service.ts:170](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/service.ts#L170)
+Defined in: [src/resources/service.ts:170](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/service.ts#L170)
 
 ## Type declaration
 

--- a/docs/variable/functions/collectionUpsert.md
+++ b/docs/variable/functions/collectionUpsert.md
@@ -8,7 +8,7 @@
 
 > **collectionUpsert**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/variable.ts#L17)
+Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/variable.ts#L17)
 
 Upsert a variable collection
 

--- a/docs/variable/functions/collectionUpsert.md
+++ b/docs/variable/functions/collectionUpsert.md
@@ -8,7 +8,7 @@
 
 > **collectionUpsert**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/variable.ts#L17)
+Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/variable.ts#L17)
 
 Upsert a variable collection
 

--- a/docs/variable/functions/collectionUpsert.md
+++ b/docs/variable/functions/collectionUpsert.md
@@ -8,7 +8,7 @@
 
 > **collectionUpsert**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/variable.ts#L17)
+Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/variable.ts#L17)
 
 Upsert a variable collection
 

--- a/docs/variable/functions/collectionUpsert.md
+++ b/docs/variable/functions/collectionUpsert.md
@@ -8,7 +8,7 @@
 
 > **collectionUpsert**(`input`): `Promise`\<`void`\>
 
-Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/variable.ts#L17)
+Defined in: [src/resources/variable.ts:17](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/variable.ts#L17)
 
 Upsert a variable collection
 

--- a/docs/variable/variables/default.md
+++ b/docs/variable/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/variable.ts#L39)
+Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/variable.ts#L39)
 
 ## Type declaration
 

--- a/docs/variable/variables/default.md
+++ b/docs/variable/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/4121e2accb658089536ab841cb74fe6d1e324c80/src/resources/variable.ts#L39)
+Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/variable.ts#L39)
 
 ## Type declaration
 

--- a/docs/variable/variables/default.md
+++ b/docs/variable/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/7b9552361fc20fed3464e55a0e1e03a30f1cf591/src/resources/variable.ts#L39)
+Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/50c12a64efaa7c3e3b78d9501e1fcf2fb3093eed/src/resources/variable.ts#L39)
 
 ## Type declaration
 

--- a/docs/variable/variables/default.md
+++ b/docs/variable/variables/default.md
@@ -8,7 +8,7 @@
 
 > **default**: `object`
 
-Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/3e8b838d15db81260f7bb15024aab7e38c8a7088/src/resources/variable.ts#L39)
+Defined in: [src/resources/variable.ts:39](https://github.com/meistrari/railway-sdk/blob/9ff19e1cb7961b52cf6d6acde3a59454380a6228/src/resources/variable.ts#L39)
 
 ## Type declaration
 

--- a/src/resources/deployment.ts
+++ b/src/resources/deployment.ts
@@ -120,6 +120,13 @@ async function cancel(deploymentId: string) {
   return response.deploymentCancel
 }
 
+/**
+ * Create a deployment
+ * @param input - The input parameters
+ * @param input.environmentId - The ID of the environment
+ * @param input.serviceId - The ID of the service
+ * @param input.commitSha - The commit SHA to deploy
+ */
 async function create(input: {
   environmentId: string
   serviceId: string

--- a/src/resources/deployment.ts
+++ b/src/resources/deployment.ts
@@ -120,7 +120,35 @@ async function cancel(deploymentId: string) {
   return response.deploymentCancel
 }
 
+async function create(input: {
+  environmentId: string
+  serviceId: string
+  commitSha?: string
+}) {
+  interface Response {
+    data: {
+      deploymentCreate: boolean
+    }
+  }
+
+  const params = {
+    environmentId: input.environmentId,
+    serviceId: input.serviceId,
+    commitSha: input.commitSha,
+    ...(input.commitSha ? { latestCommit: !input.commitSha } : {}),
+  }
+
+  const response = await graphQLRequest<Response>(`
+    mutation {
+      deploymentCreate(input: ${graphQLifyObject(params)})
+    }
+  `)
+
+  return response.data.deploymentCreate
+}
+
 export default {
   list,
   cancel,
+  create,
 }

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -89,8 +89,65 @@ async function createDomain(input: {
   return response.serviceDomainCreate.domain
 }
 
+async function getForEnvironment(input: {
+  environmentId: string
+}) {
+  interface Response {
+    data: {
+      environment: {
+        serviceInstances: {
+          edges: Array<{
+            node: {
+              serviceName: string
+              serviceId: string
+              domains: {
+                customDomains: Array<{
+                  domain: string
+                }>
+                serviceDomains: Array<{
+                  domain: string
+                }>
+              }
+            }
+          }>
+        }
+      }
+    }
+  }
+
+  const response = await graphQLRequest<Response>(`
+      query MyQuery {
+        environment(id: "${input.environmentId}") {
+          serviceInstances {
+            edges {
+              node {
+                serviceName
+                serviceId
+                domains {
+                  customDomains {
+                    domain
+                  },
+                  serviceDomains {
+                    domain
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+  `)
+
+  return response.data.environment.serviceInstances.edges.map(edge => ({
+    serviceName: edge.node.serviceName,
+    serviceId: edge.node.serviceId,
+    domains: edge.node.domains,
+  }))
+}
+
 export default {
   getById,
   getDomains,
   createDomain,
+  getForEnvironment,
 }

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -6,8 +6,8 @@ import graphQLRequest from '../helper'
 
 /**
  * Get a service by ID
- * @param {string} serviceId - The ID of the service to get
- * @returns {Promise<object>} The service
+ * @param serviceId - The ID of the service to get
+ * @returns The service
  */
 export async function getById(serviceId: string) {
   interface Response {
@@ -29,6 +29,14 @@ export async function getById(serviceId: string) {
   return service.service
 }
 
+/**
+ * Get domains for a service in an environment
+ * @param input - The input parameters
+ * @param input.projectId - The ID of the project
+ * @param input.environmentId - The ID of the environment
+ * @param input.serviceId - The ID of the service
+ * @returns The custom and service domains
+ */
 async function getDomains(input: {
   projectId: string
   environmentId: string
@@ -63,6 +71,14 @@ async function getDomains(input: {
   }
 }
 
+/**
+ * Create a service domain
+ * @param input - The input parameters
+ * @param input.environmentId - The ID of the environment
+ * @param input.serviceId - The ID of the service
+ * @param input.targetPort - The target port for the domain
+ * @returns The created domain
+ */
 async function createDomain(input: {
   environmentId: string
   serviceId: string
@@ -89,6 +105,12 @@ async function createDomain(input: {
   return response.serviceDomainCreate.domain
 }
 
+/**
+ * Get all service instances for an environment
+ * @param input - The input parameters
+ * @param input.environmentId - The ID of the environment
+ * @returns Array of service instances with their domains
+ */
 async function getForEnvironment(input: {
   environmentId: string
 }) {


### PR DESCRIPTION
## Context
This PR adds new functionality for managing services and deployments in the Railway SDK:

- **Service Management**: Added `getForEnvironment` method to retrieve all service instances for a given environment, including their domains
- **Deployment Management**: Added `create` method to trigger new deployments with optional commit SHA specification
- **Documentation**: Improved TSDoc comments across service and deployment modules, removing JSDoc-style type annotations in favor of TypeScript's native type system

These enhancements provide better programmatic control over Railway services and deployments.

## Changes
- Added `service.getForEnvironment()` to query all services in an environment
- Added `deployment.create()` to trigger deployments programmatically
- Updated all service and deployment function documentation to use proper TSDoc format
- Generated documentation updates via TypeDoc